### PR TITLE
Right-click context menu and chat counter

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "electron": "concurrently -k \"BROWSER=none yarn dev\" \"wait-on tcp:5173 && electron .\"",
+    "electron": "concurrently -k \"cross-env BROWSER=none yarn dev\" \"wait-on tcp:5173 && electron .\"",
     "pack": "yarn build && electron-builder --dir",
     "make": "yarn build && electron-builder"
   },
@@ -45,6 +45,7 @@
   "dependencies": {
     "@dqbd/tiktoken": "^1.0.2",
     "@react-oauth/google": "^0.9.0",
+    "electron-in-page-search": "^1.3.2",
     "electron-is-dev": "^2.0.0",
     "electron-squirrel-startup": "^1.0.0",
     "electron-updater": "^5.3.0",
@@ -79,6 +80,7 @@
     "@vitejs/plugin-react-swc": "^3.0.0",
     "autoprefixer": "^10.4.13",
     "concurrently": "^8.0.1",
+    "cross-env": "^7.0.3",
     "electron": "^23.2.0",
     "electron-builder": "^24.4.0",
     "postcss": "^8.4.21",

--- a/src/components/Menu/ChatCounter.tsx
+++ b/src/components/Menu/ChatCounter.tsx
@@ -1,0 +1,13 @@
+import { useState, useEffect } from 'react';
+import useStore from '@store/store';
+
+export const useChatCounter = () => {
+  const getChats = useStore((state) => state.chats);
+  const [chatCount, setChatCount] = useState<number>(0);
+
+  useEffect(() => {
+    setChatCount(getChats?.length || 0);
+  }, [getChats]);
+
+  return chatCount;
+};

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -1,5 +1,7 @@
+//Searchbar.tsx
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useChatCounter } from '../Menu/ChatCounter';  // import the useChatCounter hook
 
 const SearchBar = ({
   value,
@@ -13,6 +15,7 @@ const SearchBar = ({
   disabled?: boolean;
 }) => {
   const { t } = useTranslation();
+  const chatCount = useChatCounter();  // use the hook
 
   return (
     <div className={className}>
@@ -20,7 +23,7 @@ const SearchBar = ({
         disabled={disabled}
         type='text'
         className='text-gray-800 dark:text-white p-3 text-sm bg-transparent disabled:opacity-40  disabled:cursor-not-allowed transition-opacity m-0 w-full h-full focus:outline-none rounded border border-white/20'
-        placeholder={t('search') as string}
+        placeholder={`${t('search')} (${chatCount} chats)`}  // modify the placeholder text
         value={value}
         onChange={(e) => {
           handleChange(e);


### PR DESCRIPTION
- Added a chat counter that is displayed inside the chat search bar placeholder text.

- Added a right-click context menu in the Electron app that allows the user to: undo, redo, cut, copy, paste, delete, and select all. Also includes spellcheck correction and 'add to dictionary'.

- Added cross-platform functionality for the browser function.